### PR TITLE
Refactor architecture to automatically detect dependencies.

### DIFF
--- a/demos/src/demo3.ts
+++ b/demos/src/demo3.ts
@@ -1,6 +1,6 @@
 /// <reference types="@webgpu/types" />
 
-import { useEffect, useUnit } from "@gpu-fu/gpu-fu"
+import { useUnit } from "@gpu-fu/gpu-fu"
 import {
   TextureSourceBitmapFromURL,
   TextureFilterConvolve,

--- a/gpu-fu/index.ts
+++ b/gpu-fu/index.ts
@@ -5,11 +5,9 @@ export {
   useProp,
   useInitializedProp,
   useUnit,
-  useUnitProp,
   useGPUResource,
-  useGPUAction,
+  useGPUUpdate,
   useEffect,
-  useAsyncPropSetter,
 } from "./src/hooks"
 
 export { default as TextureSource } from "./src/TextureSource"

--- a/gpu-fu/src/Context.ts
+++ b/gpu-fu/src/Context.ts
@@ -1,7 +1,11 @@
 /// <reference types="@webgpu/types" />
 
 import { Unit } from "./Unit"
-import { Property, PropertyImplementation } from "./Property"
+import { Property, PropertyImplementation, PropertyReadOnly } from "./Property"
+import { Derived, DerivedImplementation } from "./Derived"
+import { OperationImplementation } from "./Operation"
+import { EffectImplementation } from "./Effect"
+import { Effect } from "./Effect"
 
 export type MaybeDestroyableGPUResource =
   | undefined
@@ -9,249 +13,76 @@ export type MaybeDestroyableGPUResource =
   | false
   | null
   | (GPUObjectBase & { destroy?: () => void })
-export type StoreItemGPUResource<T extends MaybeDestroyableGPUResource> = [
-  T,
-  unknown[],
-]
 
-export type StoreItemGPUAction = [
-  (ctx: ContextForGPUAction) => void,
-  unknown[],
-  boolean,
-]
+type AttachDependency = Pick<
+  DerivedImplementation<unknown>,
+  "_attachDependency"
+>
 
-export type StoreItemEffect = [(() => void) | undefined, unknown[]]
+export class ContextImplementation {
+  _currentAction?: AttachDependency
+  _currentClockNumber: number = 1
 
-export class ContextImplementation<U> {
-  private _unitFn: (ctx: Context) => U
+  _effects: Effect[] = []
 
-  device: GPUDevice
-  commandEncoder?: GPUCommandEncoder
+  _device: GPUDevice
+  _commandEncoder?: GPUCommandEncoder
 
-  constructor(unitFn: (ctx: Context) => U, device: GPUDevice) {
-    this._unitFn = unitFn
-    this.device = device
+  constructor(device: GPUDevice) {
+    this._device = device
   }
 
-  ///
-  // This next section relates to private storage of state and effects.
-
-  private _store: unknown[] = []
-  private _storeIndex = 0
-  private _storeUnits: Property<Unit<unknown> | undefined>[] = []
-  private _storeUnitsIndex = 0
-  private _storeGPUActions: StoreItemGPUAction[] = []
-  private _storeGPUActionsIndex = 0
-  _needsUnitReRun = true // TODO: private
-
-  private _nextStoreIndex() {
-    const storeIndex = this._storeIndex
-    this._storeIndex = storeIndex + 1
-    return storeIndex
+  get commandEncoder(): GPUCommandEncoder | undefined {
+    return this._commandEncoder
   }
 
-  private _nextStoreUnitsIndex() {
-    const storeUnitsIndex = this._storeUnitsIndex
-    this._storeUnitsIndex = storeUnitsIndex + 1
-    return storeUnitsIndex
+  get device(): GPUDevice {
+    return this._device
   }
-
-  private _nextStoreGPUActionsIndex() {
-    const storeGPUActionsIndex = this._storeGPUActionsIndex
-    this._storeGPUActionsIndex = storeGPUActionsIndex + 1
-    return storeGPUActionsIndex
-  }
-
-  ///
-  // This next section has public methods related to running the unit.
-
-  runUnitIfNeeded(currentUnit: U) {
-    var otherUnitsRan = false
-    this._storeUnits.forEach((unitProp) => {
-      const unit = unitProp.current
-      const otherUnitRan = unit?._ctx.runUnitIfNeeded(unit)
-      if (otherUnitRan) otherUnitsRan = true
-    })
-
-    if (this._needsUnitReRun || otherUnitsRan) {
-      this._storeIndex = 0
-      this._storeUnitsIndex = 0
-      this._storeGPUActionsIndex = 0
-      this._needsUnitReRun = false
-      Object.assign(currentUnit, this._unitFn(this))
-      return true
-    } else {
-      return false
-    }
-  }
-
-  runGPUActionsIfNeeded(commandEncoder: GPUCommandEncoder) {
-    this._storeUnits.forEach((unitProp) => {
-      const unit = unitProp.current
-      unit?._ctx.runGPUActionsIfNeeded(commandEncoder)
-    })
-
-    this.commandEncoder = commandEncoder
-    this._storeGPUActions.forEach(([action, deps, needsRun], index) => {
-      if (needsRun) {
-        action(this as ContextForGPUAction)
-        this._storeGPUActions[index][2] = false
-      }
-    })
-    this.commandEncoder = undefined
-  }
-
-  ///
-  // This next section has public methods
 
   _useProp<T>(initialValue: (() => T) | T): Property<T> {
-    const storeIndex = this._nextStoreIndex()
-    const existing = this._store[storeIndex] as Property<T>
-
-    // If there is an existing property pair, return it now.
-    if (existing) return existing
-
-    // Otherwise create, store, and return a new prop/setProp pair,
-    // using the provided initial state value or function.
-    const prop: Property<T> = new PropertyImplementation<T, U>(
+    return new PropertyImplementation<T>(
       typeof initialValue === "function"
         ? (initialValue as () => T)()
         : initialValue,
       this,
     )
-
-    this._store[storeIndex] = prop
-    return prop
-  }
-
-  _useUnitProp<T extends Unit<unknown> | undefined>(
-    initialValue: (() => T) | T,
-  ): Property<T> {
-    const storeIndex = this._nextStoreUnitsIndex()
-    const existing = this._storeUnits[storeIndex] as Property<T>
-
-    // If there is an existing prop/setProp pair, return it now.
-    if (existing) return existing
-
-    // Otherwise create, store, and return a new prop/setProp pair,
-    // using the provided initial state value or function.
-    const prop: Property<T> = new PropertyImplementation<T, U>(
-      typeof initialValue === "function"
-        ? (initialValue as () => T)()
-        : initialValue,
-      this,
-    )
-
-    this._storeUnits[storeIndex] = prop
-    return prop
   }
 
   _useGPUResource<T extends MaybeDestroyableGPUResource>(
-    create: (ctx: ContextForGPUResource) => T,
-    deps: Array<unknown>,
-  ): T {
-    const storeIndex = this._nextStoreIndex()
-    const existing = this._store[storeIndex] as StoreItemGPUResource<T>
-
-    // If the resource has never been created, create it now.
-    if (!existing) {
-      const newResource = create(this)
-      this._store[storeIndex] = [newResource, deps]
-      return newResource
-    }
-
-    // If the resource exists, and all new dependencies have the same identity
-    // as the corresponding old dependencies, return the existing resource.
-    if (deps.every((dep, index) => dep === existing[1][index]))
-      return existing[0]
-
-    // Create the new resource and store it along with its dependencies.
-    const newResource = create(this)
-    const oldResource = existing[0]
-    existing[0] = newResource
-    existing[1] = deps
-
-    // Destroy the old resource if applicable.
-    if (oldResource && typeof oldResource.destroy === "function")
-      oldResource.destroy()
-
-    // Return the new resource
-    return newResource
+    fn: (ctx: ContextForGPUResource) => T,
+  ): Derived<T> {
+    return new DerivedImplementation<T>(this, fn as any)
   }
 
-  _useGPUAction(
-    action: (ctx: ContextForGPUAction) => void,
-    deps: Array<unknown>,
-  ): void {
-    const storeIndex = this._nextStoreGPUActionsIndex()
-    const existing = this._storeGPUActions[storeIndex] as StoreItemGPUAction
-
-    // If the action has never been stored, store it now and return early.
-    if (!existing) {
-      this._storeGPUActions[storeIndex] = [action, deps, true]
-      return
-    }
-
-    // If the action is known, and all new dependencies have the same identity
-    // as the corresponding old dependencies, return without doing anything.
-    if (deps.every((dep, index) => dep === existing[1][index])) return
-
-    // Update the action function along with its dependencies,
-    // and mark it as being "dirty" (i.e. in need of being executed again).
-    existing[0] = action
-    existing[1] = deps
-    existing[2] = true
-    return
-  }
-
-  _useEffect(
-    effect: (ctx: ContextEmpty) => (() => void) | undefined,
-    deps: Array<unknown>,
+  _useGPUUpdate(
+    producedProps: PropertyReadOnly<unknown>[],
+    fn: (ctx: ContextForGPUAction) => void,
   ) {
-    const storeIndex = this._nextStoreIndex()
-    const existing = this._store[storeIndex] as StoreItemEffect
+    const op = new OperationImplementation(this, fn as any)
 
-    // If the effect has never been stored, store it now after executing.
-    if (!existing) {
-      const cancelFn = effect({})
-      this._store[storeIndex] = [cancelFn, deps]
-      return
-    }
+    producedProps.forEach((prop) => prop._attachProducerOperation(op))
+  }
 
-    // If the effect is known, and all new dependencies have the same identity
-    // as the corresponding old dependencies, return without doing anything.
-    if (deps.every((dep, index) => dep === existing[1][index])) return
-
-    // Call the existing cancel function if there is one.
-    if (existing[0]) existing[0]()
-
-    // Execute the effect function to get the new cancel function, then
-    // store it along with the new dependency identities.
-    existing[0] = effect({})
-    existing[1] = deps
-    return
+  _useEffect(fn: (ctx: ContextEmpty) => (() => void) | undefined) {
+    this._effects.push(new EffectImplementation(this, fn as any))
   }
 }
 
 export type Context = Pick<
-  ContextImplementation<unknown>,
+  ContextImplementation,
   // In the main function context, hooks are available.
-  | "device"
-  | "_useProp"
-  | "_useUnitProp"
-  | "_useGPUResource"
-  | "_useGPUAction"
-  | "_useEffect"
+  "device" | "_useProp" | "_useGPUResource" | "_useGPUUpdate" | "_useEffect"
 >
 
 export type ContextForGPUResource = Pick<
-  ContextImplementation<unknown>,
+  ContextImplementation,
   // No hooks are available.
   "device"
 >
 
 export type ContextForGPUAction = Pick<
-  ContextImplementation<unknown>,
+  ContextImplementation,
   // No hooks are available, but a command encoder is available.
   "device"
 > & { commandEncoder: GPUCommandEncoder }

--- a/gpu-fu/src/Derived.ts
+++ b/gpu-fu/src/Derived.ts
@@ -1,0 +1,78 @@
+import { ContextImplementation } from "./Context"
+import { Operation } from "./Operation"
+import { PropertyReadOnly } from "./Property"
+
+export type Derived<T> = PropertyReadOnly<T>
+
+export class DerivedImplementation<T> implements Derived<T> {
+  _ctx: ContextImplementation
+  _fn: (ctx: unknown) => T
+  _deps = new Set<PropertyReadOnly<unknown>>()
+  _cachedResult?: T
+  _cachedClockNumber: number = 0
+  _producedClockNumber = 0
+  _producerOperations: Operation[] = []
+
+  constructor(ctx: ContextImplementation, fn: (ctx: unknown) => T) {
+    this._ctx = ctx
+    this._fn = fn
+  }
+
+  _attachDependency(dep: PropertyReadOnly<unknown>): void {
+    this._deps.add(dep)
+  }
+
+  _attachProducerOperation(op: Operation): void {
+    this._producerOperations.push(op)
+  }
+
+  _runIfNeededAt(clockNumber: number): boolean {
+    if (this._cachedClockNumber >= clockNumber) return true
+
+    var depsChanged = false
+    this._deps.forEach((dep) => {
+      if (dep._runIfNeededAt(clockNumber)) depsChanged = true
+    })
+    if (!depsChanged && this._cachedClockNumber > 0) return false
+
+    const outerAction = this._ctx._currentAction
+    this._ctx._currentAction = this
+
+    // Run the destroy method of the previous result to clean up if applicable.
+    const previousResult = this._cachedResult
+    if (
+      typeof previousResult === "object" &&
+      "destroy" in previousResult &&
+      typeof (previousResult as any).destroy === "function"
+    ) {
+      ;(previousResult as any).destroy()
+    }
+
+    this._cachedResult = this._fn(this._ctx)
+    this._cachedClockNumber = clockNumber
+
+    this._ctx._currentAction = outerAction
+
+    return true
+  }
+
+  _produceIfNeededAt(clockNumber: number) {
+    if (this._producedClockNumber >= clockNumber) return
+
+    this._producerOperations.forEach((op) => op._produceIfNeededAt(clockNumber))
+    this._producedClockNumber = clockNumber
+  }
+
+  get current(): T {
+    const currentDerived = this._ctx._currentAction
+    if (!currentDerived)
+      throw new Error(
+        "It's only possible to read properties from within a reactive context",
+      )
+    currentDerived._attachDependency(this)
+
+    this._runIfNeededAt(this._ctx._currentClockNumber)
+
+    return this._cachedResult as T
+  }
+}

--- a/gpu-fu/src/Effect.ts
+++ b/gpu-fu/src/Effect.ts
@@ -1,0 +1,48 @@
+import { ContextImplementation } from "./Context"
+import { PropertyReadOnly } from "./Property"
+
+export type Effect = Pick<
+  EffectImplementation,
+  "_attachDependency" | "_runIfNeededAt"
+>
+
+export class EffectImplementation implements Effect {
+  _ctx: ContextImplementation
+  _fn: (ctx: unknown) => (() => {}) | undefined
+  _deps = new Set<PropertyReadOnly<unknown>>()
+  _lastCancelFn?: () => {}
+  _lastClockNumber = 0
+
+  constructor(
+    ctx: ContextImplementation,
+    fn: (ctx: unknown) => (() => {}) | undefined,
+  ) {
+    this._ctx = ctx
+    this._fn = fn
+  }
+
+  _attachDependency(dep: PropertyReadOnly<unknown>): void {
+    this._deps.add(dep)
+  }
+
+  _runIfNeededAt(clockNumber: number) {
+    if (this._lastClockNumber >= clockNumber) return true
+
+    var depsChanged = false
+    this._deps.forEach((dep) => {
+      if (dep._runIfNeededAt(clockNumber)) depsChanged = true
+    })
+    if (!depsChanged && this._lastClockNumber > 0) return false
+
+    const lastCancelFn = this._lastCancelFn
+    if (lastCancelFn) lastCancelFn()
+
+    const outerAction = this._ctx._currentAction
+    this._ctx._currentAction = this
+
+    this._lastCancelFn = this._fn(this._ctx)
+
+    this._ctx._currentAction = outerAction
+    this._lastClockNumber = clockNumber
+  }
+}

--- a/gpu-fu/src/MatrixSource.ts
+++ b/gpu-fu/src/MatrixSource.ts
@@ -1,5 +1,7 @@
 /// <reference types="@webgpu/types" />
 
+import { PropertyReadOnly } from "./Property"
+
 export default interface MatrixSource {
-  cameraSourceAsGPUBuffer: GPUBuffer
+  cameraSourceAsGPUBuffer: PropertyReadOnly<GPUBuffer>
 }

--- a/gpu-fu/src/Operation.ts
+++ b/gpu-fu/src/Operation.ts
@@ -1,0 +1,38 @@
+import { ContextImplementation } from "./Context"
+import { PropertyReadOnly } from "./Property"
+
+export type Operation = Pick<
+  OperationImplementation,
+  "_produceIfNeededAt" | "_attachDependency"
+>
+
+export class OperationImplementation implements Operation {
+  _ctx: ContextImplementation
+  _fn: (ctx: unknown) => void
+  _deps = new Set<PropertyReadOnly<unknown>>()
+  _producedClockNumber: number = 0
+
+  constructor(ctx: ContextImplementation, fn: (ctx: unknown) => void) {
+    this._ctx = ctx
+    this._fn = fn
+  }
+
+  _attachDependency(dep: PropertyReadOnly<unknown>): void {
+    this._deps.add(dep)
+  }
+
+  _produceIfNeededAt(clockNumber: number) {
+    if (this._producedClockNumber >= clockNumber) return
+    this._producedClockNumber = clockNumber
+
+    this._deps.forEach((op) => op._runIfNeededAt(clockNumber))
+    this._deps.forEach((op) => op._produceIfNeededAt(clockNumber))
+
+    const outerAction = this._ctx._currentAction
+    this._ctx._currentAction = this
+
+    this._fn(this._ctx)
+
+    this._ctx._currentAction = outerAction
+  }
+}

--- a/gpu-fu/src/TextureSource.ts
+++ b/gpu-fu/src/TextureSource.ts
@@ -1,5 +1,7 @@
 /// <reference types="@webgpu/types" />
 
+import { PropertyReadOnly } from "./Property"
+
 export default interface TextureSource {
-  textureSourceAsGPUTexture: GPUTexture
+  textureSourceAsGPUTexture: PropertyReadOnly<GPUTexture | undefined>
 }

--- a/gpu-fu/src/VertexSource.ts
+++ b/gpu-fu/src/VertexSource.ts
@@ -1,7 +1,9 @@
 /// <reference types="@webgpu/types" />
 
+import { PropertyReadOnly } from "./Property"
+
 export default interface VertexSource {
-  vertexSourceAsGPUBuffer: GPUBuffer
+  vertexSourceAsGPUBuffer: PropertyReadOnly<GPUBuffer>
   vertexSourceCount: number
   vertexSourceTotalBytes: number
   vertexSourceStrideBytes: number

--- a/incubator/src/MatrixSourceOrbitalCameraWithControls.ts
+++ b/incubator/src/MatrixSourceOrbitalCameraWithControls.ts
@@ -6,98 +6,85 @@ export default function MatrixSourceOrbitalCameraWithControls(ctx: Context) {
   const cameraSource = MatrixSourceOrbitalCamera(ctx)
   const canvas = useProp<HTMLCanvasElement>(ctx)
 
-  useEffect(
-    ctx,
-    (ctx) => {
-      const currentCanvas = canvas.current
-      if (!currentCanvas) return () => {}
+  useEffect(ctx, (ctx) => {
+    const currentCanvas = canvas.current
+    if (!currentCanvas) return () => {}
 
-      const maxLatitudeRadians = Math.PI / 2 - 0.05
-      var lastClientX = 0
-      var lastClientY = 0
+    const maxLatitudeRadians = Math.PI / 2 - 0.05
+    var lastClientX = 0
+    var lastClientY = 0
 
-      const onPointerMove = (event: PointerEvent) => {
-        const deltaX = event.clientX - lastClientX
-        const deltaY = event.clientY - lastClientY
-        lastClientX = event.clientX
-        lastClientY = event.clientY
+    const onPointerMove = (event: PointerEvent) => {
+      const deltaX = event.clientX - lastClientX
+      const deltaY = event.clientY - lastClientY
+      lastClientX = event.clientX
+      lastClientY = event.clientY
 
-        if (event.altKey) {
-          const longitudeRadians =
-            cameraSource.cameraPosition.current.longitudeRadians
-          const latitudeRadians =
-            cameraSource.cameraPosition.current.latitudeRadians
+      if (event.altKey) {
+        const longitudeRadians =
+          cameraSource.cameraPosition.current.longitudeRadians
+        const latitudeRadians =
+          cameraSource.cameraPosition.current.latitudeRadians
 
-          // The 2D X axis is always perpendicular to the 3D Y axis, so changes
-          // along the 2D X axis never affect the 3D Y axis.
-          // However, changes along the 2D Y axis can affect all three axes.
-          const scale = 0.02 // TODO: compute based on current cameraDistance, canvas size, field of view, etc.
-          const deltaY3D = scale * deltaY * Math.cos(latitudeRadians)
-          const deltaX3D =
-            scale *
-            (deltaX * -Math.cos(longitudeRadians) +
-              deltaY * Math.sin(latitudeRadians) * Math.sin(longitudeRadians))
-          const deltaZ3D =
-            scale *
-            (deltaX * Math.sin(longitudeRadians) +
-              deltaY * Math.sin(latitudeRadians) * Math.cos(longitudeRadians))
+        // The 2D X axis is always perpendicular to the 3D Y axis, so changes
+        // along the 2D X axis never affect the 3D Y axis.
+        // However, changes along the 2D Y axis can affect all three axes.
+        const scale = 0.02 // TODO: compute based on current cameraDistance, canvas size, field of view, etc.
+        const deltaY3D = scale * deltaY * Math.cos(latitudeRadians)
+        const deltaX3D =
+          scale *
+          (deltaX * -Math.cos(longitudeRadians) +
+            deltaY * Math.sin(latitudeRadians) * Math.sin(longitudeRadians))
+        const deltaZ3D =
+          scale *
+          (deltaX * Math.sin(longitudeRadians) +
+            deltaY * Math.sin(latitudeRadians) * Math.cos(longitudeRadians))
 
-          // TODO: Use `mutate` instead of `change`, to preserve the same vec3.
-          cameraSource.targetPosition.change(
-            (current) =>
-              vec3.fromValues(
-                current[0] + deltaX3D,
-                current[1] + deltaY3D,
-                current[2] + deltaZ3D,
-              ) as Float32Array,
+        cameraSource.targetPosition.mutate((vector) => {
+          vector[0] += deltaX3D
+          vector[1] += deltaY3D
+          vector[2] += deltaZ3D
+        })
+      } else {
+        cameraSource.cameraPosition.mutate((data) => {
+          data.longitudeRadians -= deltaX * 0.01
+          data.latitudeRadians = Math.min(
+            maxLatitudeRadians,
+            Math.max(-maxLatitudeRadians, data.latitudeRadians - deltaY * 0.01),
           )
-        } else {
-          // TODO: Use `mutate` instead of `change`, to preserve the same object.
-          cameraSource.cameraPosition.change((current) => ({
-            distance: current.distance,
-            longitudeRadians: current.longitudeRadians - deltaX * 0.01,
-            latitudeRadians: Math.min(
-              maxLatitudeRadians,
-              Math.max(
-                -maxLatitudeRadians,
-                current.latitudeRadians - deltaY * 0.01,
-              ),
-            ),
-          }))
-        }
+        })
       }
+    }
 
-      const onPointerDown = (event: PointerEvent) => {
-        currentCanvas.style.cursor = "grabbing"
+    const onPointerDown = (event: PointerEvent) => {
+      currentCanvas.style.cursor = "grabbing"
 
-        lastClientX = event.clientX
-        lastClientY = event.clientY
+      lastClientX = event.clientX
+      lastClientY = event.clientY
 
-        currentCanvas.addEventListener("pointermove", onPointerMove)
-        currentCanvas.setPointerCapture(event.pointerId)
-      }
+      currentCanvas.addEventListener("pointermove", onPointerMove)
+      currentCanvas.setPointerCapture(event.pointerId)
+    }
 
-      const onPointerUp = (event: PointerEvent) => {
-        currentCanvas.style.cursor = "grab"
-
-        currentCanvas.removeEventListener("pointermove", onPointerMove)
-      }
-
+    const onPointerUp = (event: PointerEvent) => {
       currentCanvas.style.cursor = "grab"
 
-      currentCanvas.addEventListener("pointerdown", onPointerDown)
-      currentCanvas.addEventListener("pointerup", onPointerUp)
+      currentCanvas.removeEventListener("pointermove", onPointerMove)
+    }
 
-      return () => {
-        currentCanvas.style.cursor = "auto"
+    currentCanvas.style.cursor = "grab"
 
-        currentCanvas.removeEventListener("pointerdown", onPointerDown)
-        currentCanvas.removeEventListener("pointerup", onPointerUp)
-        currentCanvas.removeEventListener("pointermove", onPointerMove)
-      }
-    },
-    [canvas.current],
-  )
+    currentCanvas.addEventListener("pointerdown", onPointerDown)
+    currentCanvas.addEventListener("pointerup", onPointerUp)
+
+    return () => {
+      currentCanvas.style.cursor = "auto"
+
+      currentCanvas.removeEventListener("pointerdown", onPointerDown)
+      currentCanvas.removeEventListener("pointerup", onPointerUp)
+      currentCanvas.removeEventListener("pointermove", onPointerMove)
+    }
+  })
 
   return Object.assign(cameraSource, { canvas })
 }

--- a/incubator/src/OutputCanvas.ts
+++ b/incubator/src/OutputCanvas.ts
@@ -18,8 +18,8 @@ export default class OutputCanvas {
   outputFrame(commandEncoder: GPUCommandEncoder) {
     const target = this._canvasContext.getCurrentTexture()
     this._renders.forEach((render) => {
-      render.renderTarget.set(target)
-      render.runFrame(commandEncoder)
+      render.renderTarget.setAndNotify(target)
+      render.runFrame(commandEncoder, [render.renderTarget])
     })
   }
 }

--- a/incubator/src/RenderUV.ts
+++ b/incubator/src/RenderUV.ts
@@ -2,183 +2,155 @@
 
 import {
   Context,
+  Unit,
   MatrixSource,
   VertexSource,
   TextureSource,
   autoLayout,
   useProp,
-  useUnitProp,
   useGPUResource,
-  useGPUAction,
+  useGPUUpdate,
 } from "@gpu-fu/gpu-fu"
 
 import shaderModuleCode from "./RenderUV.wgsl"
 
 export default function RenderUV(ctx: Context) {
-  const cameraSource = useUnitProp<MatrixSource>(ctx)
-  const vertexSource = useUnitProp<VertexSource>(ctx)
-  const textureSource = useUnitProp<TextureSource>(ctx)
+  const cameraSource = useProp<Unit<MatrixSource>>(ctx)
+  const vertexSource = useProp<Unit<VertexSource>>(ctx)
+  const textureSource = useProp<Unit<TextureSource>>(ctx)
   const renderTarget = useProp<GPUTexture>(ctx)
 
-  const cameraSourceAsGPUBuffer = cameraSource.current?.cameraSourceAsGPUBuffer
-  const textureSourceAsGPUTexture =
-    textureSource.current?.textureSourceAsGPUTexture
-
-  const shaderModule = useGPUResource(
-    ctx,
-    (ctx) =>
-      ctx.device.createShaderModule({
-        code: shaderModuleCode,
-      }),
-    [],
+  const shaderModule = useGPUResource(ctx, (ctx) =>
+    ctx.device.createShaderModule({
+      code: shaderModuleCode,
+    }),
   )
 
-  const renderPipeline = useGPUResource(
-    ctx,
-    (ctx) => {
-      if (!vertexSource.current) return
+  const renderPipeline = useGPUResource(ctx, (ctx) => {
+    if (!vertexSource.current) return
 
-      return ctx.device.createRenderPipeline({
-        vertex: {
-          module: shaderModule,
-          entryPoint: cameraSourceAsGPUBuffer
-            ? "vertexRenderUVWithMatrix"
-            : "vertexRenderUV",
-          buffers: [
-            {
-              arrayStride: vertexSource.current.vertexSourceStrideBytes,
-              attributes: [
-                {
-                  shaderLocation: 0,
-                  offset: vertexSource.current.vertexSourceXYZWOffsetBytes,
-                  format: "float32x4" as GPUVertexFormat,
-                },
-                {
-                  shaderLocation: 1,
-                  offset: vertexSource.current.vertexSourceUVOffsetBytes,
-                  format: "float32x2" as GPUVertexFormat,
-                },
-              ],
-            },
-          ],
-        },
-        fragment: {
-          module: shaderModule,
-          entryPoint: "fragmentRenderUV",
-          targets: [
-            {
-              // TODO: Remove this hard-coded value - get the real one somehow.
-              format: "rgba8unorm" as GPUTextureFormat,
-            },
-          ],
-        },
-        primitive: {
-          topology: "triangle-list",
-          // TODO: Configurable `cullMode`
-        },
-        depthStencil: {
-          depthWriteEnabled: true,
-          depthCompare: "less",
-          format: "depth24plus",
-        },
-        layout: autoLayout(),
-      })
-    },
-    [shaderModule, vertexSource.current],
-  )
-
-  const sampler = useGPUResource(
-    ctx,
-    (ctx) =>
-      ctx.device.createSampler({
-        magFilter: "linear",
-        minFilter: "linear",
-      }),
-    [],
-  )
-
-  const bindGroup = useGPUResource(
-    ctx,
-    (ctx) => {
-      if (!renderPipeline) return
-      if (!textureSourceAsGPUTexture) return
-
-      const entries: GPUBindGroupEntry[] = [
-        {
-          binding: 1,
-          resource: sampler,
-        },
-        {
-          binding: 2,
-          resource: textureSourceAsGPUTexture.createView(),
-        },
-      ]
-      if (cameraSourceAsGPUBuffer)
-        entries.unshift({
-          binding: 0,
-          resource: { buffer: cameraSourceAsGPUBuffer },
-        })
-
-      return ctx.device.createBindGroup({
-        layout: renderPipeline.getBindGroupLayout(0),
-        entries,
-      })
-    },
-
-    [
-      renderPipeline,
-      cameraSourceAsGPUBuffer,
-      textureSourceAsGPUTexture,
-      sampler,
-    ],
-  )
-
-  const depthTexture = useGPUResource(
-    ctx,
-    (ctx) =>
-      ctx.device.createTexture({
-        size: [300, 300], // TODO: somehow get from canvas client size
-        format: "depth24plus",
-        usage: GPUTextureUsage.RENDER_ATTACHMENT,
-      }),
-    [],
-  )
-
-  useGPUAction(
-    ctx,
-    (ctx) => {
-      if (!vertexSource.current) return
-      if (!renderTarget.current) return
-      if (!renderPipeline) return
-      if (!bindGroup) return
-
-      const passEncoder = ctx.commandEncoder.beginRenderPass({
-        colorAttachments: [
+    return ctx.device.createRenderPipeline({
+      vertex: {
+        module: shaderModule.current,
+        entryPoint: cameraSource.current?.cameraSourceAsGPUBuffer
+          ? "vertexRenderUVWithMatrix"
+          : "vertexRenderUV",
+        buffers: [
           {
-            view: renderTarget.current.createView(),
-            clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
-            loadOp: "clear" as GPULoadOp,
-            storeOp: "store" as GPUStoreOp,
+            arrayStride: vertexSource.current.vertexSourceStrideBytes,
+            attributes: [
+              {
+                shaderLocation: 0,
+                offset: vertexSource.current.vertexSourceXYZWOffsetBytes,
+                format: "float32x4" as GPUVertexFormat,
+              },
+              {
+                shaderLocation: 1,
+                offset: vertexSource.current.vertexSourceUVOffsetBytes,
+                format: "float32x2" as GPUVertexFormat,
+              },
+            ],
           },
         ],
-        depthStencilAttachment: {
-          view: depthTexture.createView(),
-          depthClearValue: 1.0,
-          depthLoadOp: "clear" as GPULoadOp,
-          depthStoreOp: "store" as GPUStoreOp,
+      },
+      fragment: {
+        module: shaderModule.current,
+        entryPoint: "fragmentRenderUV",
+        targets: [
+          {
+            // TODO: Remove this hard-coded value - get the real one somehow.
+            format: "rgba8unorm" as GPUTextureFormat,
+          },
+        ],
+      },
+      primitive: {
+        topology: "triangle-list",
+        // TODO: Configurable `cullMode`
+      },
+      depthStencil: {
+        depthWriteEnabled: true,
+        depthCompare: "less",
+        format: "depth24plus",
+      },
+      layout: autoLayout(),
+    })
+  })
+
+  const sampler = useGPUResource(ctx, (ctx) =>
+    ctx.device.createSampler({
+      magFilter: "linear",
+      minFilter: "linear",
+    }),
+  )
+
+  const bindGroup = useGPUResource(ctx, (ctx) => {
+    if (!renderPipeline.current) return
+    if (!textureSource.current?.textureSourceAsGPUTexture.current) return
+
+    const entries: GPUBindGroupEntry[] = [
+      {
+        binding: 1,
+        resource: sampler.current,
+      },
+      {
+        binding: 2,
+        resource:
+          textureSource.current?.textureSourceAsGPUTexture.current.createView(),
+      },
+    ]
+    if (cameraSource.current?.cameraSourceAsGPUBuffer)
+      entries.unshift({
+        binding: 0,
+        resource: {
+          buffer: cameraSource.current?.cameraSourceAsGPUBuffer.current,
         },
       })
-      passEncoder.setPipeline(renderPipeline)
-      passEncoder.setVertexBuffer(
-        0,
-        vertexSource.current.vertexSourceAsGPUBuffer,
-      )
-      passEncoder.setBindGroup(0, bindGroup)
-      passEncoder.draw(vertexSource.current.vertexSourceCount, 1, 0, 0)
-      passEncoder.end()
-    },
-    [vertexSource.current, renderTarget.current, renderPipeline, bindGroup],
+
+    return ctx.device.createBindGroup({
+      layout: renderPipeline.current.getBindGroupLayout(0),
+      entries,
+    })
+  })
+
+  const depthTexture = useGPUResource(ctx, (ctx) =>
+    ctx.device.createTexture({
+      size: [300, 300], // TODO: somehow get from canvas client size
+      format: "depth24plus",
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    }),
   )
+
+  useGPUUpdate([renderTarget], ctx, (ctx) => {
+    if (!vertexSource.current) return
+    if (!renderTarget.current) return
+    if (!renderPipeline.current) return
+    if (!bindGroup.current) return
+
+    const passEncoder = ctx.commandEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: renderTarget.current.createView(),
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: "clear" as GPULoadOp,
+          storeOp: "store" as GPUStoreOp,
+        },
+      ],
+      depthStencilAttachment: {
+        view: depthTexture.current.createView(),
+        depthClearValue: 1.0,
+        depthLoadOp: "clear" as GPULoadOp,
+        depthStoreOp: "store" as GPUStoreOp,
+      },
+    })
+    passEncoder.setPipeline(renderPipeline.current)
+    passEncoder.setVertexBuffer(
+      0,
+      vertexSource.current.vertexSourceAsGPUBuffer.current,
+    )
+    passEncoder.setBindGroup(0, bindGroup.current)
+    passEncoder.draw(vertexSource.current.vertexSourceCount, 1, 0, 0)
+    passEncoder.end()
+  })
 
   return {
     cameraSource,

--- a/incubator/src/TextureFilterConvolve.ts
+++ b/incubator/src/TextureFilterConvolve.ts
@@ -1,13 +1,13 @@
 /// <reference types="@webgpu/types" />
 
 import {
+  Context,
+  Unit,
   TextureSource,
   autoLayout,
-  Context,
   useGPUResource,
-  useGPUAction,
   useProp,
-  useUnitProp,
+  useGPUUpdate,
 } from "@gpu-fu/gpu-fu"
 
 import shaderModuleCode3x3 from "./TextureFilterConvolve3x3.wgsl"
@@ -19,12 +19,8 @@ interface SetKernelOptions {
 }
 
 export default function TextureFilterConvolve(ctx: Context) {
-  const textureSource = useUnitProp<TextureSource>(ctx)
+  const textureSource = useProp<Unit<TextureSource>>(ctx)
   const kernelData = useProp<Float32Array>(ctx)
-
-  const textureSourceAsGPUTexture =
-    textureSource.current?.textureSourceAsGPUTexture
-  const kernelDataByteLength = kernelData.current?.byteLength
 
   function setKernel3x3(
     row0: [number, number, number],
@@ -60,123 +56,112 @@ export default function TextureFilterConvolve(ctx: Context) {
   const kernelBuffer = useGPUResource(
     ctx,
     (ctx) =>
-      kernelDataByteLength &&
+      kernelData.current?.byteLength &&
       ctx.device.createBuffer({
-        size: kernelDataByteLength,
+        size: kernelData.current?.byteLength,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
       }),
-    [kernelDataByteLength],
   )
 
-  useGPUAction(
-    ctx,
-    (ctx) => {
-      if (!kernelBuffer) return
-      if (!kernelData.current) return
+  useGPUUpdate([kernelBuffer], ctx, (ctx) => {
+    if (!kernelBuffer.current) return
+    if (!kernelData.current) return
 
-      ctx.device.queue.writeBuffer(
-        kernelBuffer,
-        0,
-        kernelData.current,
-        0,
-        kernelData.current.length,
-      )
-    },
-    [kernelBuffer, kernelData.current],
-  )
+    ctx.device.queue.writeBuffer(
+      kernelBuffer.current,
+      0,
+      kernelData.current,
+      0,
+      kernelData.current.length,
+    )
+  })
 
-  const computePipeline = useGPUResource(
-    ctx,
-    (ctx) => {
-      let shaderModuleCode: string
-      switch (kernelData.current?.length) {
-        case 10:
-          shaderModuleCode = shaderModuleCode3x3
-          break
-        default:
-          return
-      }
+  const computePipeline = useGPUResource(ctx, (ctx) => {
+    let shaderModuleCode: string
+    switch (kernelData.current?.length) {
+      case 10:
+        shaderModuleCode = shaderModuleCode3x3
+        break
+      default:
+        return
+    }
 
-      return ctx.device.createComputePipeline({
-        compute: {
-          module: ctx.device.createShaderModule({
-            code: shaderModuleCode,
-          }),
-          entryPoint: "computeTextureFilterConvolve3x3",
-        },
-        layout: autoLayout(),
-      })
-    },
-    [kernelData.current?.length],
-  )
+    return ctx.device.createComputePipeline({
+      compute: {
+        module: ctx.device.createShaderModule({
+          code: shaderModuleCode,
+        }),
+        entryPoint: "computeTextureFilterConvolve3x3",
+      },
+      layout: autoLayout(),
+    })
+  })
 
-  const texture = useGPUResource(
-    ctx,
-    (ctx) =>
-      ctx.device.createTexture({
-        format: "rgba8unorm",
-        size: {
-          width: textureSourceAsGPUTexture?.width || 850, // TODO: remove fallback value
-          height: textureSourceAsGPUTexture?.height || 1275, // TODO: remove fallback value
-        },
-        usage:
-          GPUTextureUsage.COPY_DST |
-          GPUTextureUsage.STORAGE_BINDING |
-          GPUTextureUsage.TEXTURE_BINDING,
-      }),
-    [textureSourceAsGPUTexture],
+  const texture = useGPUResource(ctx, (ctx) =>
+    ctx.device.createTexture({
+      format: "rgba8unorm",
+      size: {
+        width:
+          textureSource.current?.textureSourceAsGPUTexture.current?.width ||
+          850, // TODO: remove fallback value
+        height:
+          textureSource.current?.textureSourceAsGPUTexture.current?.height ||
+          1275, // TODO: remove fallback value
+      },
+      usage:
+        GPUTextureUsage.COPY_DST |
+        GPUTextureUsage.STORAGE_BINDING |
+        GPUTextureUsage.TEXTURE_BINDING,
+    }),
   )
 
   const bindGroup = useGPUResource(
     ctx,
     (ctx) =>
-      computePipeline &&
-      kernelBuffer &&
-      textureSourceAsGPUTexture &&
-      texture &&
+      computePipeline.current &&
+      kernelBuffer.current &&
+      textureSource.current?.textureSourceAsGPUTexture.current &&
+      texture.current &&
       ctx.device.createBindGroup({
-        layout: computePipeline.getBindGroupLayout(0),
+        layout: computePipeline.current.getBindGroupLayout(0),
         entries: [
           {
             binding: 0,
-            resource: { buffer: kernelBuffer },
+            resource: { buffer: kernelBuffer.current },
           },
           {
             binding: 1,
-            resource: textureSourceAsGPUTexture.createView(),
+            resource:
+              textureSource.current?.textureSourceAsGPUTexture.current?.createView(),
           },
           {
             binding: 2,
-            resource: texture.createView(),
+            resource: texture.current.createView(),
           },
         ],
       }),
-    [computePipeline, kernelBuffer, textureSourceAsGPUTexture, texture],
   )
 
-  useGPUAction(
-    ctx,
-    (ctx) => {
-      if (!textureSourceAsGPUTexture) return
-      if (!computePipeline) return
-      if (!bindGroup) return
+  useGPUUpdate([texture], ctx, (ctx) => {
+    if (!textureSource.current?.textureSourceAsGPUTexture.current) return
+    if (!computePipeline.current) return
+    if (!bindGroup.current) return
 
-      const workGroupSizeX = 32 // (must match the WGSL code)
-      const workGroupSizeY = 1 // (must match the WGSL code)
+    const workGroupSizeX = 32 // (must match the WGSL code)
+    const workGroupSizeY = 1 // (must match the WGSL code)
 
-      const passEncoder = ctx.commandEncoder.beginComputePass()
-      passEncoder.setPipeline(computePipeline)
-      passEncoder.setBindGroup(0, bindGroup)
-      passEncoder.dispatch(
-        (textureSourceAsGPUTexture.width || 850) / // TODO: remove fallback value
-          workGroupSizeX,
-        (textureSourceAsGPUTexture.height || 1275) / // TODO: remove fallback value
-          workGroupSizeY,
-      )
-      passEncoder.end()
-    },
-    [textureSourceAsGPUTexture, computePipeline, bindGroup],
-  )
+    const passEncoder = ctx.commandEncoder.beginComputePass()
+    passEncoder.setPipeline(computePipeline.current)
+    passEncoder.setBindGroup(0, bindGroup.current)
+    passEncoder.dispatch(
+      (textureSource.current?.textureSourceAsGPUTexture.current?.width || 850) / // TODO: remove fallback value
+        workGroupSizeX,
+      (textureSource.current?.textureSourceAsGPUTexture.current?.height ||
+        1275) / // TODO: remove fallback value
+        workGroupSizeY,
+    )
+    passEncoder.end()
+  })
 
   return {
     textureSource,

--- a/incubator/src/TextureSourceBitmap.ts
+++ b/incubator/src/TextureSourceBitmap.ts
@@ -1,43 +1,35 @@
 /// <reference types="@webgpu/types" />
 
-import { Context, useProp, useGPUResource, useGPUAction } from "@gpu-fu/gpu-fu"
+import { Context, useProp, useGPUResource, useGPUUpdate } from "@gpu-fu/gpu-fu"
 
 export default function TextureSourceBitmap(ctx: Context) {
   const imageBitmap = useProp<ImageBitmap>(ctx)
   const label = useProp<string>(ctx)
 
-  const textureWidth = imageBitmap.current?.width ?? 16 // TODO: remove fallback values
-  const textureHeight = imageBitmap.current?.height ?? 16 // TODO: remove fallback values
+  const texture = useGPUResource(ctx, (ctx) => {
+    if (!imageBitmap.current) return
 
-  const texture = useGPUResource(
-    ctx,
-    (ctx) =>
-      ctx.device.createTexture({
-        label: label.current,
-        size: [textureWidth, textureHeight, 1],
-        format: "rgba8unorm",
-        usage:
-          GPUTextureUsage.TEXTURE_BINDING |
-          GPUTextureUsage.COPY_DST |
-          GPUTextureUsage.RENDER_ATTACHMENT,
-      }),
-    [textureWidth, textureHeight, label.current],
-  )
+    return ctx.device.createTexture({
+      label: label.current,
+      size: [imageBitmap.current.width, imageBitmap.current.height, 1],
+      format: "rgba8unorm",
+      usage:
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.COPY_DST |
+        GPUTextureUsage.RENDER_ATTACHMENT,
+    })
+  })
 
-  useGPUAction(
-    ctx,
-    (ctx) => {
-      if (!imageBitmap.current) return
-      if (!texture) return
+  useGPUUpdate([texture], ctx, (ctx) => {
+    if (!imageBitmap.current) return
+    if (!texture.current) return
 
-      ctx.device.queue.copyExternalImageToTexture(
-        { source: imageBitmap.current },
-        { texture: texture },
-        [imageBitmap.current.width, imageBitmap.current.height],
-      )
-    },
-    [imageBitmap.current, texture],
-  )
+    ctx.device.queue.copyExternalImageToTexture(
+      { source: imageBitmap.current },
+      { texture: texture.current },
+      [imageBitmap.current.width, imageBitmap.current.height],
+    )
+  })
 
   return {
     imageBitmap,

--- a/incubator/src/VertexSourceIcosahedron.ts
+++ b/incubator/src/VertexSourceIcosahedron.ts
@@ -1,6 +1,6 @@
 /// <reference types="@webgpu/types" />
 
-import { Context, useGPUResource, useGPUAction } from "@gpu-fu/gpu-fu"
+import { Context, useGPUResource, useGPUUpdate } from "@gpu-fu/gpu-fu"
 
 const vertexSourceCount = 60
 const vertexSourceXYZWOffsetBytes = 0
@@ -9,30 +9,25 @@ const vertexSourceStrideBytes = 6 * 4
 const vertexSourceTotalBytes = vertexSourceCount * vertexSourceStrideBytes
 
 export default function VertexSourceIcosahedron(ctx: Context) {
-  const buffer = useGPUResource(
-    ctx,
-    (ctx) =>
-      ctx.device.createBuffer({
-        size: vertexSourceTotalBytes,
-        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
-      }),
-    [],
+  const buffer = useGPUResource(ctx, (ctx) =>
+    ctx.device.createBuffer({
+      size: vertexSourceTotalBytes,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    }),
   )
 
-  useGPUAction(
-    ctx,
-    (ctx) => {
-      if (!buffer) return
+  useGPUUpdate([buffer], ctx, (ctx) => {
+    if (!buffer.current) return
 
-      var uMin = 0
-      var uMax = 1
-      var vMin = 0
-      var vMax = 1
+    var uMin = 0
+    var uMax = 1
+    var vMin = 0
+    var vMax = 1
 
-      const t = (1 + Math.sqrt(5)) / 2
+    const t = (1 + Math.sqrt(5)) / 2
 
-      // prettier-ignore
-      const data = new Float32Array([
+    // prettier-ignore
+    const data = new Float32Array([
       // (x, y, z, w),  (u, v)
           t, 1, 0, 1, uMax, vMin, // v0
           0, t, 1, 1, uMax, vMax, // v8
@@ -115,10 +110,8 @@ export default function VertexSourceIcosahedron(ctx: Context) {
          -t, 1, 0, 1, uMin, vMax, // v7
       ])
 
-      ctx.device.queue.writeBuffer(buffer, 0, data, 0, data.length)
-    },
-    [buffer],
-  )
+    ctx.device.queue.writeBuffer(buffer.current, 0, data, 0, data.length)
+  })
 
   return {
     vertexSourceCount,

--- a/incubator/src/VertexSourceRect.ts
+++ b/incubator/src/VertexSourceRect.ts
@@ -1,6 +1,6 @@
 /// <reference types="@webgpu/types" />
 
-import { Context, useProp, useGPUAction, useGPUResource } from "@gpu-fu/gpu-fu"
+import { Context, useProp, useGPUUpdate, useGPUResource } from "@gpu-fu/gpu-fu"
 
 const vertexSourceCount = 6
 const vertexSourceTotalBytes = 6 * 6 * 4
@@ -11,38 +11,33 @@ const vertexSourceUVOffsetBytes = 4 * 4
 export default function VertexSourceRect(ctx: Context) {
   const aspectFillRatio = useProp<number>(ctx)
 
-  const buffer = useGPUResource(
-    ctx,
-    (ctx) =>
-      ctx.device.createBuffer({
-        size: vertexSourceTotalBytes,
-        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
-      }),
-    [],
+  const buffer = useGPUResource(ctx, (ctx) =>
+    ctx.device.createBuffer({
+      size: vertexSourceTotalBytes,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    }),
   )
 
-  useGPUAction(
-    ctx,
-    (ctx) => {
-      if (!buffer) return
+  useGPUUpdate([buffer], ctx, (ctx) => {
+    if (!buffer.current) return
 
-      var uMin = 0
-      var uMax = 1
-      var vMin = 0
-      var vMax = 1
+    var uMin = 0
+    var uMax = 1
+    var vMin = 0
+    var vMax = 1
 
-      if (aspectFillRatio.current) {
-        if (aspectFillRatio.current < 1) {
-          vMin = 0.5 - 0.5 * aspectFillRatio.current
-          vMax = 1 - vMin
-        } else {
-          uMin = 0.5 - 0.5 / aspectFillRatio.current
-          uMax = 1 - uMin
-        }
+    if (aspectFillRatio.current) {
+      if (aspectFillRatio.current < 1) {
+        vMin = 0.5 - 0.5 * aspectFillRatio.current
+        vMax = 1 - vMin
+      } else {
+        uMin = 0.5 - 0.5 / aspectFillRatio.current
+        uMax = 1 - uMin
       }
+    }
 
-      // prettier-ignore
-      const data = new Float32Array([
+    // prettier-ignore
+    const data = new Float32Array([
       // (x, y, z, w),  (u, v)
           1, 1, 0, 1, uMax, vMin,
          -1,-1, 0, 1, uMin, vMax,
@@ -52,10 +47,8 @@ export default function VertexSourceRect(ctx: Context) {
          -1,-1, 0, 1, uMin, vMax,
       ])
 
-      ctx.device.queue.writeBuffer(buffer, 0, data, 0, data.length)
-    },
-    [buffer, aspectFillRatio.current],
-  )
+    ctx.device.queue.writeBuffer(buffer.current, 0, data, 0, data.length)
+  })
 
   return {
     aspectFillRatio,


### PR DESCRIPTION
Instead of using a truly React Hooks style of explicitly writing
dependencies for hook functions (and requiring the user to get
the list just right, or subtle bugs will happen), this new
implementation will automatically track dependencies of things
that you call `.current` on from within the reactive hook.

Also, calling `.current` on a property outside of a reactive hook
will produce a runtime error that fails loudly, allowing you to
ensure that dependencies are always tracked to keep things reactive.